### PR TITLE
New Language Mode for Task MC_CU and corrections in task descriptions

### DIFF
--- a/tasks/implementation/VHDL/MC_CU/generator.sh
+++ b/tasks/implementation/VHDL/MC_CU/generator.sh
@@ -18,6 +18,7 @@ task_nr=$2
 submission_email=$3
 mode=$4
 semester_db=$5
+language=$6
 
 ##########################
 ########## PATHS #########
@@ -47,7 +48,7 @@ fi
 ##########################
 cd ${task_path}
 
-task_parameters=$(python3 scripts/generateTask.py "${user_id}" "${task_nr}" "${submission_email}")
+task_parameters=$(python3 scripts/generateTask.py "${user_id}" "${task_nr}" "${submission_email}" "${language}")
 
 # copy multicycle processor image from static to tmp directory
 cp static/Multicycle_Processor_V_1_3.pdf tmp
@@ -77,13 +78,13 @@ rm bytefield.sty
 mv ${task_path}/tmp/desc_${user_id}_Task${task_nr}.pdf ${desc_path}
 
 #copy static files to user's description folder
-cp $task_path/static/MC_CU_beh.vhdl $desc_path
-cp $task_path/static/MC_CU.vhdl $desc_path
+cp ${task_path}/static/MC_CU_beh.vhdl ${desc_path}
+cp ${task_path}/static/MC_CU.vhdl ${desc_path}
 
 ##########################
 ##   EMAIL ATTACHMENTS  ##
 ##########################
-task_attachments="$desc_path/desc_${user_id}_Task${task_nr}.pdf $desc_path/MC_CU.vhdl $desc_path/MC_CU_beh.vhdl"
+task_attachments="${desc_path}/desc_${user_id}_Task${task_nr}.pdf ${desc_path}/MC_CU.vhdl ${desc_path}/MC_CU_beh.vhdl"
 
 ##########################
 ## ADD TASK TO DATABASE ##

--- a/tasks/implementation/VHDL/MC_CU/scripts/generateTask.py
+++ b/tasks/implementation/VHDL/MC_CU/scripts/generateTask.py
@@ -13,14 +13,16 @@ import sys
 from random import randrange, shuffle
 import string
 
-class MyTemplate(string.Template):
-    delimiter = "%%"
+from jinja2 import FileSystemLoader, Environment
+
+import json
 
 #################################################################
 
 user_id=sys.argv[1]
 task_nr=sys.argv[2]
 submission_email=sys.argv[3]
+language=sys.argv[4]
 
 params_desc={}
 
@@ -38,69 +40,48 @@ while(second_instruction == first_instruction): # do not use the same instructio
 
 task_parameters=str(first_instruction)+"|"+str(second_instruction)
 
+###################################
+## IMPORT LANGUAGE TEXT SNIPPETS ##
+###################################
+
+filename ="templates/task_description/language_support_files/lang_snippets_{0}.json".format(language)
+with open(filename) as data_file:
+    lang_data = json.load(data_file)
+
 ################################################
 # GENERATE PARAMETERS FOR DESCRIPTION TEMPLATE #
 ################################################
 
-instruction_table_text =	["add         & 000000 & 100000 & R  \\\\",	# 0
-					 "sub         & 000000 & 100010 & R  \\\\",	# 1
-					 "and         & 000000 & 100100 & R  \\\\",	# 2
-					 "or          & 000000 & 100101 & R  \\\\",	# 3
-					 "xor         & 000000 & 100110 & R  \\\\",	# 4
-					 "nor         & 000000 & 100111 & R  \\\\",	# 5
-					 "slt         & 000000 & 101010 & R  \\\\",	# 6
-					 "j           & 000010 &    -   & J  \\\\",	# 7
-					 "lw          & 100011 &    -   & I  \\\\",	# 8
-					 "sw          & 101011 &    -   & I  \\\\",	# 9
-					 "addi        & 001000 &    -   & I  \\\\",	# 10
-					 "beq         & 000100 &    -   & I  \\\\",	# 11
-					 "bne         & 000101 &    -   & I  \\\\"]	# 12
 
-ALUControls = ["000        & add \\\\",
-		   "010        & sub \\\\",
-		   "100        & and \\\\",
-		   "101        & or  \\\\",
-		   "110        & xor \\\\",
-		   "111        & nor \\\\",
-		   "001        & slt \\\\" ]
 
-instruction_names = ["add",
-	               "sub",
-	               "and",
-	               "or",
-	               "xor",
-	               "nor",
-	               "slt",
-	               "j",
-	               "lw",
-	               "sw",
-	               "addi",
-	               "beq",
-	               "bne"]
+instruction_text = 	[	"\\vspace{-2mm}\n"
+				"\\subsection*{%instruction_name}\n"
+				+lang_data["instruction_text"][0],
 
-instruction_text = ["\\vspace{-2mm}\n"
-			  "\\subsection*{%instruction_name}\n"
-			  "This instruction performs an ALU operation with two register values and saves the result to a register. It takes two clock cycles. First the registers specified in rs and rt are loaded into the ALU and the ALU is sent the %instruction_name control signal. %slt_explanation The ALUControl signal for %instruction_name can be found in Table~1. In the next clock cycle the ALU Result is saved into the register specified by rd.",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{j}\n"
-			  "This instruction performs an unconditional jump to the address specified in the instruction. It takes one clock cycle. During this clock cycle the bits 25 -- 0 of the instruction are shiftet left by 2 bits. They are then used as the bits 27 -- 0 of the new program counter value (PC') together with bits 31 -- 28 of the current program counter value (PC).",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{lw}\n"
-			  "This instruction loads a data word from data memory into the registers. It takes three clock cycles. First the data memory address is being determined by addition in the ALU. The operands for the ALU are the register specified in rs and an immediate value specified in bits 15 -- 0 of the instruction. During the next clock cycle the result of the ALU is used as a read address from the data memory. In the third clock cycle the data read from data memory is written to the register specified by rd.",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{sw}\n"
-			  "This instruction stores a data word from the registers into data memory. It takes two clock cycles. First the data memory address is being calculated by addition in the ALU. The operands for the ALU are the register specified in rs and an immediate value specified in bits 15 -- 0 of the instruction. During the next clock cycle the result of the ALU is used as a write address for the data memory. The written data comes from the register specified by rd.",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{addi}\n"
-			  "This instruction performs an addition using the ALU with a register value and an immediate value. It takes two clock cycles. First the register value specified in rs and the immediate value are added in the ALU. In the next clock cycle the ALU Result is saved into the register specified by rt.",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{beq}\n"
-			  "This instruction compares two registers and on equality branches to an address specified in the immediate value. It takes only one clock cycle, but as mentioned above, the branching address has to be prepared already while decoding. Then in the clock cycle after decoding a beq instruction, registers specified by rs and rd are compared on equality by substraction in the ALU. If the ALU operation result is zero, then it sets its Zero output to `1'. The control unit has asynchronous logic which sets the PCWrite signal to `1' in case the Zero flag is `1' during the beq instruction. This writes a new value to the PC register, and thus performs the branching.",
-			  "\\vspace{-2mm}\n"
-			  "\\subsection*{bne}\n"
-			  "This instruction compares two registers and if they are not equal, branches to an address specified in the immediate value. It takes only one clock cycle, but as mentioned above, the branching address has to be prepared already while decoding. Then in the clock cycle after decoding a bne instruction, registers specified by rs and rd are compared on equality by substraction in the ALU. If the ALU operation result is zero, then it sets its Zero output to `1'. The control unit has asynchronous logic which sets the PCWrite signal to `1' in case the Zero flag is not `1' during the bne instruction. This writes a new value to the PC register, and thus performs the branching."]
+				"\\vspace{-2mm}\n"
+				"\\subsection*{j}\n"
+				+lang_data["instruction_text"][1],
 
-slt_explanation = "The slt ALUControl signal compares the two ALU operands, and sets the ALU Result to 1 in case rs $<$ rt. The ALU Result is set to 0 otherwise."
+				"\\vspace{-2mm}\n"
+				"\\subsection*{lw}\n"
+				+lang_data["instruction_text"][2],
+
+				"\\vspace{-2mm}\n"
+				"\\subsection*{sw}\n"
+				+lang_data["instruction_text"][3],
+
+				"\\vspace{-2mm}\n"
+				"\\subsection*{addi}\n"
+				+lang_data["instruction_text"][4],
+
+				"\\vspace{-2mm}\n"
+				"\\subsection*{beq}\n"
+				+lang_data["instruction_text"][5],
+
+				"\\vspace{-2mm}\n"
+				"\\subsection*{bne}\n"
+				+lang_data["instruction_text"][6]
+			]
 
 # add description for selected instruction types:
 selected_instruction_type_text = ""
@@ -115,8 +96,8 @@ if (first_instruction <= 6) or (second_instruction <= 6):
 							  "        \\bitbox{6}{opcode} & \\bitbox{5}{rs} & \\bitbox{5}{rt} & \\bitbox{5}{rd} &\n"
 							  "        \\bitbox{5}{\\textcolor{grau}{unused}} & \\bitbox{6}{funct}\n"
 							  "    \\end{bytefield}\n"
-							  "\\end{table}\n"
-							  "With the opcode representing the instruction, rs and rt the source registers and rd the destination register and funct representing an instruction for the ALU. The R-type instruction processes the two source registers in the ALU. The ALU result is saved in the destination register specified by rd.\\\\ \n")
+							  "\\end{table}\n")
+	selected_instruction_type_text += (lang_data["Instr_Typ_cap"][0])
 
 if (first_instruction == 7) or (second_instruction == 7):
 	selected_instruction_type_text += ("\\vspace{-2mm}\n"
@@ -128,8 +109,8 @@ if (first_instruction == 7) or (second_instruction == 7):
 							  "        \\bitheader[b]{0,25,26,31}\\\\\n"
 							  "        \\bitbox{6}{opcode} & \\bitbox{26}{address}\n"
 							  "    \\end{bytefield}\n"
-							  "\\end{table}\n"
-							  "With the opcode representing the instruction and the address being part of a 32 bit address. The 32 bit address is constructed by using the first four bits of the program counter as most significant bits, concatenating the 16 bit address from the instruction and setting the two least significant bits to 0.\\\\ \n")
+							  "\\end{table}\n")
+	selected_instruction_type_text += (lang_data["Instr_Typ_cap"][1])
 
 if (first_instruction >= 8) or (second_instruction >= 8):
 	selected_instruction_type_text += ("\\vspace{-2mm}\n"
@@ -141,25 +122,25 @@ if (first_instruction >= 8) or (second_instruction >= 8):
 							  "        \\bitheader[b]{0,15,16,20,21,25,26,31}\\\\\n"
 							  "        \\bitbox{6}{opcode} & \\bitbox{5}{rs} & \\bitbox{5}{rt} & \\bitbox{16}{IMM}\n"
 							  "    \\end{bytefield}\n"
-							  "\end{table}\n"
-							  "With the opcode representing the instruction, rs a source register and IMM the immediate value. The usage of rt depends on the instruction, see below for details.\\\\ \n")
+							  "\\end{table}\n")
+	selected_instruction_type_text += (lang_data["Instr_Typ_cap"][2])
 
 # add additional text if beq or bne instruction:
 beq_bne_decode_addition = ""
 if (first_instruction >= 11) or (second_instruction >= 11):
-	beq_bne_decode_addition += "Because the instruction might be a "
+	beq_bne_decode_addition += lang_data["Instr_Text_helpers"][1]
 	if (first_instruction >= 11) and (second_instruction >= 11):
-		beq_bne_decode_addition += "beq/bne"
+		beq_bne_decode_addition += lang_data["Instr_Text_helpers"][2]
 	elif (first_instruction == 11) or (second_instruction == 11):
-		beq_bne_decode_addition += "beq"
+		beq_bne_decode_addition += lang_data["Instr_Text_helpers"][3]
 	elif (first_instruction == 12) or (second_instruction == 12):
-		beq_bne_decode_addition += "bne"
-	beq_bne_decode_addition += " instruction which might lead to a branch to a new program counter value, this new program counter value has to be calculated during the decode clock cycle. This means during decode the rt value of the potential I-type instruction has to be added to the potential immediate value in the ALU. This makes the branching address available in the register which saves the ALU Result."
+		beq_bne_decode_addition += lang_data["Instr_Text_helpers"][4]
+	beq_bne_decode_addition += lang_data["Instr_Text_helpers"][5]
 
 
 selected_instruction_table_text = []
-selected_instruction_table_text.append(instruction_table_text[first_instruction])
-selected_instruction_table_text.append(instruction_table_text[second_instruction])
+selected_instruction_table_text.append(lang_data["instruction_table_text"][first_instruction])
+selected_instruction_table_text.append(lang_data["instruction_table_text"][second_instruction])
 
 selected_instruction_table_text=("\n"+2*"\t").join(selected_instruction_table_text) # just to make indentation
 
@@ -167,9 +148,9 @@ selected_instruction_table_text=("\n"+2*"\t").join(selected_instruction_table_te
 first_instruction_text = ""
 if (first_instruction <= 6):
 	first_instruction_text += instruction_text[0]
-	first_instruction_text = first_instruction_text.replace("%instruction_name",instruction_names[first_instruction])
+	first_instruction_text = first_instruction_text.replace("%instruction_name",lang_data["instruction_names"][first_instruction])
 	if (first_instruction == 6):
-		first_instruction_text = first_instruction_text.replace("%slt_explanation", slt_explanation)
+		first_instruction_text = first_instruction_text.replace("%slt_explanation", lang_data["Instr_Text_helpers"][0])
 	else:
 		first_instruction_text = first_instruction_text.replace("%slt_explanation", " ")
 else:
@@ -179,9 +160,9 @@ else:
 second_instruction_text = ""
 if (second_instruction <= 6):
 	second_instruction_text += instruction_text[0]
-	second_instruction_text = second_instruction_text.replace("%instruction_name",instruction_names[second_instruction])
+	second_instruction_text = second_instruction_text.replace("%instruction_name",lang_data["instruction_names"][second_instruction])
 	if (second_instruction == 6):
-		second_instruction_text = second_instruction_text.replace("%slt_explanation", slt_explanation)
+		second_instruction_text = second_instruction_text.replace("%slt_explanation", lang_data["Instr_Text_helpers"][0])
 	else:
 		second_instruction_text = second_instruction_text.replace("%slt_explanation", " ")
 else:
@@ -189,13 +170,13 @@ else:
 
 # fill ALUControl table:
 ALUControl_table = []
-ALUControl_table.append(ALUControls[0]) # we currently always need add
+ALUControl_table.append(lang_data["ALUControls"][0]) # we currently always need add
 if (first_instruction <= 6) and (first_instruction != 0):
-	ALUControl_table.append(ALUControls[first_instruction])
+	ALUControl_table.append(lang_data["ALUControls"][first_instruction])
 if (second_instruction <= 6) and (second_instruction != 0):
-	ALUControl_table.append(ALUControls[second_instruction])
+	ALUControl_table.append(lang_data["ALUControls"][second_instruction])
 if ((first_instruction >= 11) or (second_instruction >= 11)) and ((first_instruction != 1) and (second_instruction != 1)):
-	ALUControl_table.append(ALUControls[1])
+	ALUControl_table.append(lang_data["ALUControls"][1])
 
 shuffle(ALUControl_table) # make selected ALUControls order random
 
@@ -209,14 +190,15 @@ params_desc.update({"TASKNR":str(task_nr), "SUBMISSIONEMAIL":submission_email, "
 #############################
 # FILL DESCRIPTION TEMPLATE #
 #############################
-filename ="templates/task_description_template.tex"
-with open (filename, "r") as template_file:
-    data=template_file.read()
+env = Environment()
+env.loader = FileSystemLoader('templates/')
+filename ="task_description/task_description_template_{0}.tex".format(language)
+template = env.get_template(filename)
+template = template.render(params_desc)
 
 filename ="tmp/desc_{0}_Task{1}.tex".format(user_id,task_nr)
 with open (filename, "w") as output_file:
-    s = MyTemplate(data)
-    output_file.write(s.substitute(params_desc))
+    output_file.write(template)
 
 ###########################
 ### PRINT TASKPARAMETERS ##

--- a/tasks/implementation/VHDL/MC_CU/scripts/generateTestBench.py
+++ b/tasks/implementation/VHDL/MC_CU/scripts/generateTestBench.py
@@ -14,11 +14,7 @@ import sys
 import string
 from random import randrange
 
-###########################
-##### TEMPLATE CLASS ######
-###########################
-class MyTemplate(string.Template):
-    delimiter = "%%"
+from jinja2 import FileSystemLoader, Environment
 
 params={}
 
@@ -360,8 +356,11 @@ params.update({"instruction_test_1":instruction_test_1, "instruction_test_2":ins
 #####################################
 # FILL AND PRINT TESTBENCH TEMPLATE #
 #####################################
-filename ="templates/testbench_template.vhdl"
-with open (filename, "r") as template_file:
-    data=template_file.read()
-    s = MyTemplate(data)
-    print(s.substitute(params))
+env = Environment()
+env.loader = FileSystemLoader('templates/')
+filename ="testbench_template.vhdl"
+
+template = env.get_template(filename)
+template = template.render(params)
+
+print(template)

--- a/tasks/implementation/VHDL/MC_CU/templates/task_description/language_support_files/lang_snippets_de.json
+++ b/tasks/implementation/VHDL/MC_CU/templates/task_description/language_support_files/lang_snippets_de.json
@@ -1,0 +1,76 @@
+{
+
+	"Instr_Typ_cap":	[	"Der opcode repr\\\"asentiert die Instruktion, rs und rt die Quellregister (\"`source\"'), rd das Zielregister (\"`destination\"') und funct einen Befehl f\\\"ur die ALU. Das Ergebnis der ALU wird in dem durch rd angegebenen Zielregister (\"`destination\"') gespeichert.\\\\ \n",
+
+					"Der opcode repr\\\"asentiert die Instruktion und address einen Teil einer 32 Bit langen Adresse. Diese 32 Bit Adresse wird wie folgt gebildet: Die 4 h\\\"ochstwertigsten Bit entsprechen den ersten 4 Bit des Befehlsz\\\"ahlers (PC-Wert). Darauf folgt die 26 Bit Adresse (address) aus der J-type Instruktion und die zwei niederwertigsten Bit der 32 Bit Adresse werden auf 0 gesetzt.\\\\ \n",
+
+					"Der opcode repr\\\"asentiert die Instruktion, rs ein Quellregister (\"`source\"') und IMM einen Wert f\\\"ur die direkte Weiterverarbeitung (\"`immediate value\"'). Die Verwendung von rt h\\\"angt von der jeweiligen Instruktion ab (siehe Details unten).\\\\ \n"
+				],
+
+
+	"instruction_names":	[	"add",
+	               			"sub",
+	               			"and",
+	               			"or",
+	               			"xor",
+	               			"nor",
+	               			"slt",
+	              			"j",
+	               			"lw",
+	               			"sw",
+	               			"addi",
+	               			"beq",
+	               			"bne"
+				],
+
+
+	"instruction_table_text":	[	"add         & 000000 & 100000 & R  \\\\",
+						"sub         & 000000 & 100010 & R  \\\\",
+					 	"and         & 000000 & 100100 & R  \\\\",
+					 	"or          & 000000 & 100101 & R  \\\\",
+					 	"xor         & 000000 & 100110 & R  \\\\",
+					 	"nor         & 000000 & 100111 & R  \\\\",
+					 	"slt         & 000000 & 101010 & R  \\\\",
+					 	"j           & 000010 &    -   & J  \\\\",
+					 	"lw          & 100011 &    -   & I  \\\\",
+					 	"sw          & 101011 &    -   & I  \\\\",
+					 	"addi        & 001000 &    -   & I  \\\\",
+					 	"beq         & 000100 &    -   & I  \\\\",
+					 	"bne         & 000101 &    -   & I  \\\\"
+					],
+
+	"ALUControls":	[	"000        & add \\\\",
+		   		"010        & sub \\\\",
+		   		"100        & and \\\\",
+		   		"101        & or  \\\\",
+		   		"110        & xor \\\\",
+		   		"111        & nor \\\\",
+		   		"001        & slt \\\\"
+			],
+
+
+	"instruction_text":	[	"Diese Instruktion f\\\"uhrt eine ALU Operation mit zwei Registerwerten aus und speichert das Ergebnis in ein Register. Die Instruktion ben\\\"otigt 2 Taktzyklen. Zuerst werden die durch rs und rt angegebenen Register in die ALU geladen und der ALU wird gleichzeitig das Steuersignal %instruction_name gesendet. %slt_explanation Das ben\\\"otigte Steuersignal f\\\"ur die ALU finden Sie in Tabelle~1. Im n\"achsten Taktzyklus wird das ALU Ergebnis in das durch rd angegebene Register gespeichert.",
+
+					"Diese Instruktion f\\\"uhrt einen unbedingten Sprung zu der in der Instruktion angegebenen Adresse durch. Dies dauert einen Taktzyklus. W\\\"ahrend dieses Taktzyklus werden die Bits 25 -- 0 der Instruktion um 2 Bit nach links geschoben. Die resultierenden 28 Bit werden als die Bits 27 -- 0 gemeinsam mit den Bits 31 -- 28 des alten Befehlsz\\\"ahlers (PC-Wert) zu dem neuen PC-Wert kombiniert.",
+
+					"Diese Instruktion l\\\"adt ein Datenwort vom Datenspeicher \"`Data memory\"' in die Register. Dies dauert 3 Taktzyklen. Zuerst wird die Leseadresse des Datenspeichers mittels einer Addition in der ALU bestimmt. Die Operanden f\\\"ur die ALU sind der Wert des in rs angegebenen Registers und der IMM-Wert aus den Bits 15 -- 0 der Instruktion. W\\\"ahrend des zweiten Taktzyklus wird das Ergebnis der ALU vom Datenspeicher als Leseadresse \"`Address\"' verwendet. Im dritten Taktzyklus werden die aus dem Datenspeicher gelesenen Daten in das durch rt angegebene Register gespeichert.",
+
+					"Diese Instruktion speichert ein Datenwort aus den Registern in den Datenspeicher. Dies dauert 2 Taktzyklen. Zuerst wird die Speicheradresse des Datenspeichers mittels einer Addition in der ALU bestimmt. Die Operanden f\\\"ur die ALU sind der Wert des in rs angegebenen Registers und der IMM-Wert aus den Bits 15 -- 0 der Instruktion. W\\\"ahrend des zweiten Taktzyklus wird das Ergebnis der ALU als Schreibadresse \"`Address\"' f\\\"ur den Datenspeicher verwendet. Die zu speichernden Daten kommen aus dem in rt angegebenen Register",
+
+					"Diese Instruktion f\\\"uhrt mittels der ALU eine Addition eines Registerwerts mit einem IMM-Wert aus. Dies dauert 2 Taktzyklen. Zuerst wird der Wert des in rs angegeben Registers mit dem IMM-Wert der Instruktion in der ALU addiert. Im zweiten Taktzyklus wird das Ergebnis der ALU in jenem Register gespeichert, welches in rt angegeben ist.",
+
+					"Diese Instruktion vergleicht zwei Register und zweigt bei Gleicheit zu einer neuen Adresse ab, welche von dem IMM-Wert der Instruktion abh\\\"angig ist. Dieser Vorgang dauert nur einen Taktzyklus, wobei - wie zuvor erkl\\\"art - die Adresse des neuen Zweigs (\"`Branch\"') bereits w\\\"ahrend der Decodierung vorbereitet werden muss. In dem Taktzyklus nach der Decodierung der beq-Instruktion werden die in rs und rt angegebenen Register mittels eine Subtraktion in der ALU auf Gleichheit \\\"uberpr\\\"uft. Wenn das Ergebnis der ALU Null ist, dann wird der \"`Zero\"' Ausgang auf '1' gesetzt. Das Steuerwerk (\"`Control Unit\"') besitzt eine asynchrone Logik und setzt das PCWrite Signal sofort auf '1', wenn das Zero Flag w\\\"ahrend der beq-Instruktion '1' ist. Dadurch wird ein neuer Wert in das PC Register geschrieben und dies f\\\"uhrt somit zu einer Abzweigung auf eine neue Adresse.",
+
+					"Diese Instruktion vergleicht zwei Register und zweigt bei Ungleichheit zu einer neuen Adresse ab, welche von dem IMM-Wert der Instruktion abh\\\"angig ist. Dieser Vorgang dauert nur einen Taktzyklus, wobei - wie zuvor erkl\\\"art - die Adresse des neuen Zweigs (\"`Branch\"') bereits w\\\"ahrend der Decodierung vorbereitet werden muss. In dem Taktzyklus nach der Decodierung der bne-Instruktion werden die in rs und rt angegebenen Register mittels eine Subtraktion in der ALU auf Gleichheit \\\"uberpr\\\"uft. Wenn das Ergebnis der ALU Null ist, dann wird der \"`Zero\"' Ausgang auf '1' gesetzt. Das Steuerwerk (\"`Control Unit\"') besitzt eine asynchrone Logik und setzt das PCWrite Signal sofort auf '1', wenn das Zero Flag w\\\"ahrend der bne-Instruktion nicht '1' ist. Dadurch wird ein neuer Wert in das PC Register geschrieben und dies f\\\"uhrt somit zu einer Abzweigung auf eine neue Adresse."
+
+				],
+
+
+	"Instr_Text_helpers": 	[	 "Das slt ALUControl Signal vergleicht die zwei ALU Operanden und setzt das ALU Result Register auf '1', wenn rs $<$ rt erf\\\"ullt ist. Anderenfalls ist das Result Register '0'.",
+					"Da die Instruktion eine ",
+					"beq/bne",
+					"beq",
+					"bne",
+					" Instruktion sein k\\\"onnte, welche zu einem neuen Zweig (\"`Branch\"') mit einem neuen PC-Wert f\\\"uhrt, muss der neue Wert bereits w\\\"ahrend des Decodier-Taktzyklus vorberechnet werden. Dies bedeutet, dass schon w\\\"ahrend der Decodierung der aktuelle PC-Wert mit dem potentiellen IMM-Wert der Instruktion in der ALU addiert werden muss. Der IMM-Wert muss davor um 2 Bit nach links geschoben werden. Durch die Addition ist die neue Zweigadresse (neuer PC-Wert) in jenem Register verf\\\"ugbar, welches das Ergebnis der ALU speichert."
+				]
+}

--- a/tasks/implementation/VHDL/MC_CU/templates/task_description/language_support_files/lang_snippets_en.json
+++ b/tasks/implementation/VHDL/MC_CU/templates/task_description/language_support_files/lang_snippets_en.json
@@ -1,0 +1,75 @@
+{
+
+	"Instr_Typ_cap":	[	"With the opcode representing the instruction, rs and rt the source registers and rd the destination register and funct representing a function for the ALU. The R-type instruction processes the two source registers in the ALU. The ALU result is saved in the destination register specified by rd.\\\\ \n",
+
+					"With the opcode representing the instruction and the address being part of a 32 bit address. The 32 bit address is constructed by using the first four bits of the program counter as most significant bits, concatenating the 26 bit address from the J-type instruction and setting the two least significant bits to 0.\\\\ \n",
+
+					"With the opcode representing the instruction, rs a source register and IMM the immediate value. The usage of rt depends on the instruction, see below for details.\\\\ \n"
+				],
+
+
+	"instruction_names":	[	"add",
+	               			"sub",
+	               			"and",
+	               			"or",
+	               			"xor",
+	               			"nor",
+	               			"slt",
+	              			"j",
+	               			"lw",
+	               			"sw",
+	               			"addi",
+	               			"beq",
+	               			"bne"
+				],
+
+
+	"instruction_table_text":	[	"add         & 000000 & 100000 & R  \\\\",
+						 "sub         & 000000 & 100010 & R  \\\\",
+					 	"and         & 000000 & 100100 & R  \\\\",
+					 	"or          & 000000 & 100101 & R  \\\\",
+					 	"xor         & 000000 & 100110 & R  \\\\",
+					 	"nor         & 000000 & 100111 & R  \\\\",
+					 	"slt         & 000000 & 101010 & R  \\\\",
+					 	"j           & 000010 &    -   & J  \\\\",
+					 	"lw          & 100011 &    -   & I  \\\\",
+					 	"sw          & 101011 &    -   & I  \\\\",
+					 	"addi        & 001000 &    -   & I  \\\\",
+					 	"beq         & 000100 &    -   & I  \\\\",
+					 	"bne         & 000101 &    -   & I  \\\\"
+					],
+
+	"ALUControls":	[	"000        & add \\\\",
+		   		"010        & sub \\\\",
+		   		"100        & and \\\\",
+		   		"101        & or  \\\\",
+		   		"110        & xor \\\\",
+		   		"111        & nor \\\\",
+		   		"001        & slt \\\\"
+			],
+
+
+	"instruction_text":	[	"This instruction performs an ALU operation with two register values and saves the result to a register. It takes two clock cycles. First the registers specified in rs and rt are loaded into the ALU and the ALU is sent the %instruction_name control signal. %slt_explanation The ALUControl signal for %instruction_name can be found in Table~1. In the next clock cycle the ALU Result is saved into the register specified by rd.",
+
+					"This instruction performs an unconditional jump to the address specified in the instruction. It takes one clock cycle. During this clock cycle the bits 25 -- 0 of the instruction are shiftet left by 2 bits. They are then used as the bits 27 -- 0 of the new program counter value (PC') together with bits 31 -- 28 of the current program counter value (PC).",
+
+					"This instruction loads a data word from data memory into the registers. It takes three clock cycles. First the data memory address is being determined by addition in the ALU. The operands for the ALU are the register specified in rs and an immediate value specified in bits 15 -- 0 of the instruction. During the next clock cycle the result of the ALU is used as a read address from the data memory. In the third clock cycle the data read from data memory is written to the register specified by rt.",
+
+					"This instruction stores a data word from the registers into data memory. It takes two clock cycles. First the data memory address is being calculated by addition in the ALU. The operands for the ALU are the register specified in rs and an immediate value specified in bits 15 -- 0 of the instruction. During the next clock cycle the result of the ALU is used as a write address for the data memory. The written data comes from the register specified by rt.",
+
+					"This instruction performs an addition using the ALU with a register value and an immediate value. It takes two clock cycles. First the register value specified in rs and the immediate value are added in the ALU. In the next clock cycle the ALU Result is saved into the register specified by rt.",
+
+					"This instruction compares two registers and on equality branches to an address derived from the immediate value. It takes only one clock cycle, but as mentioned above, the branching address has to be prepared already while decoding. Then in the clock cycle after decoding a beq instruction, registers specified by rs and rt are compared on equality by substraction in the ALU. If the ALU operation result is zero, then it sets its Zero output to `1'. The control unit has asynchronous logic which sets the PCWrite signal to `1' in case the Zero flag is `1' during the beq instruction. This writes a new value to the PC register, and thus performs the branching.",
+
+					"This instruction compares two registers and if they are not equal, branches to an address specified in the immediate value. It takes only one clock cycle, but as mentioned above, the branching address has to be prepared already while decoding. Then in the clock cycle after decoding a bne instruction, registers specified by rs and rt are compared on equality by substraction in the ALU. If the ALU operation result is zero, then it sets its Zero output to `1'. The control unit has asynchronous logic which sets the PCWrite signal to `1' in case the Zero flag is not `1' during the bne instruction. This writes a new value to the PC register, and thus performs the branching."
+				],
+
+
+	"Instr_Text_helpers": 	[	 "The slt ALUControl signal compares the two ALU operands, and sets the ALU Result to 1 in case rs $<$ rt. The ALU Result is set to 0 otherwise.",
+					"Because the instruction might be a ",
+					"beq/bne",
+					"beq",
+					"bne",
+					" instruction which might lead to a branch to a new program counter value, this new program counter value has to be calculated during the decode clock cycle. This means during decode the current PC value has to be added to the potential immediate value in the ALU. The potential immediate value has to be shifted left by 2 Bits beforehand. This makes the branching address available in the register which saves the ALU Result."
+				]
+}

--- a/tasks/implementation/VHDL/MC_CU/templates/task_description/task_description_template_de.tex
+++ b/tasks/implementation/VHDL/MC_CU/templates/task_description/task_description_template_de.tex
@@ -1,0 +1,178 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage{a4wide}
+\usepackage{tikz}
+\usetikzlibrary{calc}
+\usepackage{hyperref}
+\usepackage{pdflscape}
+\usepackage{bytefield}
+
+\usepackage[ngerman]{babel}
+
+\newlength{\maxheight}
+\setlength{\maxheight}{\heightof{W}}
+\newcommand{\baselinealign}[1]{ %
+	\centering
+	\raisebox{0pt}[\maxheight][0pt]{ #1} %
+}
+
+\newcommand\Tstrut{\rule{0pt}{2.6ex}}       % "top" strut
+
+\definecolor{grau}{gray}{.5}
+
+\begin{document}
+\pagestyle{empty}
+\setlength{\parindent}{0em}
+\section*{\noindent Multicycle Control Unit }
+Ihre Aufgabe ist es, das Verhalten einer Entity  namens "`MC\_CU"' zu programmieren. Die Entity ist in der angeh\"angten Datei "`MC\_CU.vhdl"' mit folgenden Eigenschaften deklariert:
+
+\begin{itemize}
+	\item Eingang: CLK vom Typ std\_logic
+	\item Eingang: Opcode vom Typ std\_logic\_vector mit einer L\"ange von 6
+	\item Eingang: Funct vom Typ std\_logic\_vector mit einer L\"ange von 6
+	\item Eingang: Zero vom Typ std\_logic
+
+	\item Ausgang: PCSrc vom Typ std\_logic\_vector mit einer L\"ange von 2
+	\item Ausgang: ALUControl vom Typ std\_logic\_vector mit einer L\"ange von 3
+	\item Ausgang: ALUSrcB vom Typ std\_logic\_vector mit einer L\"ange von 2
+	\item Ausg\"ange: IRWrite, MemWrite, IorD, PCWrite, ALUSrcA, RegWrite, MemtoReg, RegDst vom Typ std\_logic
+
+\end{itemize}
+
+\begin{center}
+\begin{tikzpicture}
+\draw node [draw,rectangle, minimum height=72mm, minimum width=35mm,rounded corners=2mm,thick](entity){};
+
+\draw[->] ($ (entity.west)+(-10mm,21.6mm)$) -- ($ (entity.west) + (0mm,21.6mm)$);
+\draw[anchor=east] node at ($ (entity.west)+(-9mm,21.6mm)$){ CLK };
+
+\draw[->] ($ (entity.west)+(-10mm,7.2mm)$) -- ($ (entity.west) + (0mm,7.2mm)$);
+\draw[anchor=east] node at ($ (entity.west)+(-9mm,7.2mm)$){ Opcode };
+
+\draw[->] ($ (entity.west)+(-10mm,-7.2mm)$) -- ($ (entity.west) + (0mm,-7.2mm)$);
+\draw[anchor=east] node at ($ (entity.west)+(-9mm,-7.2mm)$){ Funct };
+
+\draw[->] ($ (entity.west)+(-10mm,-21.6mm)$) -- ($ (entity.west) + (0mm,-21.6mm)$);
+\draw[anchor=east] node at ($ (entity.west)+(-9mm,-21.6mm)$){ Zero };
+
+
+\draw[->] ($ (entity.east) + (0mm,30.0mm)$) -- ($ (entity.east) + (10mm,30.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,30.0mm)$){ IRWrite };
+
+\draw[->] ($ (entity.east) + (0mm,24.0mm)$) -- ($ (entity.east) + (10mm,24.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,24.0mm)$){ MemWrite };
+
+\draw[->] ($ (entity.east) + (0mm,18.0mm)$) -- ($ (entity.east) + (10mm,18.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,18.0mm)$){ IorD };
+
+\draw[->] ($ (entity.east) + (0mm,12.0mm)$) -- ($ (entity.east) + (10mm,12.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,12.0mm)$){ PCWrite };
+
+\draw[->] ($ (entity.east) + (0mm,6.0mm)$) -- ($ (entity.east) + (10mm,6.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,6.0mm)$){ PCSrc };
+
+\draw[->] ($ (entity.east) + (0mm,0.0mm)$) -- ($ (entity.east) + (10mm,0.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,0.0mm)$){ ALUControl };
+
+\draw[->] ($ (entity.east) + (0mm,-6.0mm)$) -- ($ (entity.east) + (10mm,-6.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,-6.0mm)$){ ALUSrcB };
+
+\draw[->] ($ (entity.east) + (0mm,-12.0mm)$) -- ($ (entity.east) + (10mm,-12.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,-12.0mm)$){ ALUSrcA };
+
+\draw[->] ($ (entity.east) + (0mm,-18.0mm)$) -- ($ (entity.east) + (10mm,-18.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,-18.0mm)$){ RegWrite };
+
+\draw[->] ($ (entity.east) + (0mm,-24.0mm)$) -- ($ (entity.east) + (10mm,-24.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,-24.0mm)$){ MemtoReg };
+
+\draw[->] ($ (entity.east) + (0mm,-30.0mm)$) -- ($ (entity.east) + (10mm,-30.0mm)$);
+\draw[anchor=west] node at ($ (entity.east) + (9mm,-30.0mm)$){ RegDst };
+
+
+\draw node at ($ (entity) - (0,0mm)$){ MC\_CU };
+
+\end{tikzpicture}
+\end{center}
+
+Ver\"andern sie die Datei "`MC\_CU.vhdl"' nicht!\\
+
+Sie m\"ussen folgende verschiedene Instruktions-Typen implementieren:
+
+{{selected_instruction_type_text}}
+
+
+Vor der Ausf\"uhrung einer Instruktion muss diese zuerst aufgerufen (fetch) und decodiert (decode) werden. Dieser Vorgang ben\"otigt 2 Taktzyklen.  W\"ahrend des Fetch-Taktzyklus wird die Instruktion von dem aktuellen Befehlsz\"ahler (PC-Wert) gelesen und in das Instruktionsregister gespeichert. Au"serdem wird in diesem Zyklus das PC Register mittels der ALU um 4 erh\"oht. Im zweiten Taktzyklus wird die Instruktion im Steuerwerk (control unit) decodiert. {{beq_bne_decode_addition}} \\
+
+Die `MC\_CU"' Entity soll den Multicycle Prozessor, welcher in Abbildung~1 dargestellt ist, so steuern, dass folgende Instruktionen ausgef\"uhrt werden k\"onnen:
+
+\begin{table}[h!]
+\centering
+    \begin{tabular}{|c|c|c|c|c|} \hline \Tstrut
+		instruction & opcode  & funct & type   \\ \hline \Tstrut
+		{{selected_instruction_table_text}}
+    \hline
+    \end{tabular}
+\end{table}
+
+{{first_instruction_text}} \\
+
+{{second_instruction_text}} \\
+
+\begin{table}[h!]
+\centering
+    \begin{tabular}{|c|c|} \hline \Tstrut
+		ALUControl & Function   \\ \hline \Tstrut
+		{{ALUControl_table}}
+    \hline
+    \end{tabular}
+    \caption{ALUControls}
+    \label{tab:ALUControls}
+\end{table}
+
+Um ein besseres Verst\"andnis f\"ur die Steuersignale zu erhalten, sei hier eine Beschreibung aller Signale gegeben. Verwenden Sie Abbildung~1 um zu verstehen, wie die Steuersignale die Datenpfade steuern.
+
+\begin{itemize}
+
+\item{IRWrite: Wenn dieses Signal auf '1' gesetzt ist, dann wird die aus dem Instruktionsspeicher gelesene Instruktion bei steigender Tanktflanke in das Instruktionsregister geschrieben.}
+
+\item{MemWrite: Wenn dieses Signal auf '1' gesetzt ist, dann schreibt der Datenspeicher die Eingangsdaten "`Write data"' bei steigender Taktflanke an die Zieladresse "`Address"'.}
+
+\item{IorD: Bestimmt, ob die Eingangsadresse "`Address"' des Datenspeichers durch das PC Register oder das Result Register der ALU ausgew\"ahlt wird.}
+
+\item{PCWrite: Wenn dieses Signal auf '1' gesetzt ist, dann wird das PC Register bei steigender Taktflanke beschrieben.}
+
+\item{PCSrc: Bestimmt, ob der neue PC-Wert direkt von der ALU, dem ALU Result Register oder der Sprungadresse festgelegt wird.}
+
+\item{ALUControl: W\"ahlt jene ALU Operation aus, welche die ALU auf ihre zwei Eingangswerte anwendet. Die Steuersignale f\"ur die verf\"ugbaren Operationen sind in Tabelle~1 gelistet.}
+
+\item{ALUSrcB:  Bestimmt, ob die ALU einen Wert von dem Register Ausgang "`Read data 2"', von einem konstanten Wert 4, von dem vorzeichenerweiterten IMM-Wert der Instruktion oder von dem vorzeichenerweiterten und um 2 Bit nach links geschobenen IMM-Wert der Instruktion erh\"alt.}
+
+\item{ALUSrcA: Bestimmt, ob die ALU einen Wert von dem Register Ausgang "`Read data 1"' oder von dem PC Register erh\"alt.}
+
+\item{RegWrite: Wenn dieses Signal auf '1' gesetzt ist, dann schreibt das Register die Daten "`Write data"' bei steigender Taktflanke in das durch "`Write register"' adressierte Register.}
+
+\item{MemtoReg: Bestimmt, ob die in das Register zu schreibenden Daten "`Write data"' entweder vom Ausgang des Datenspeichers "`Read I/D"' oder dem ALU Result Register kommen.}
+
+\item{RegDst: Bestimmt, ob die Position des zu beschreibenden Registers "`Write Register"' entweder von den Bits 20 -- 16 oder 15 -- 11 der Instruktion definiert wird. In anderen Worten entscheidet dieses Steuersignal, ob das zu beschreibende Register durch rt oder rd festgelegt wird.}
+
+\end{itemize}
+
+\"Uberlegen Sie sich, welche Aktion jeder Teil des Prozessors f\"ur die Funktion der jeweiligen Instruktionen erf\"ullen muss und setzen Sie die Steuersignale entsprechend. Programmieren Sie dieses Verhalten in der angeh\"angten Datei "`MC\_CU\_beh.vhdl"'.\\
+
+Um Ihre L\"osung abzugeben, senden Sie ein E-Mail mit dem Betreff "`Result Task {{ TASKNR }}"' und Ihrer Datei "``MC\_CU\_beh.vhdl"'  an {{ SUBMISSIONEMAIL }}.
+
+\vspace{0.7cm}
+Viel Erfolg und m\"oge die Macht mit Ihnen sein.
+
+
+\begin{landscape}
+\begin{figure}[!h]
+\vspace{-1cm}
+\hspace{-1.8cm}
+\includegraphics[width=25.5cm]{Multicycle_Processor_V_1_3}
+\caption{Multicycle processor}
+\label{fig:MulticycleProcessor}
+\end{figure}
+\end{landscape}
+
+\end{document}

--- a/tasks/implementation/VHDL/MC_CU/templates/task_description/task_description_template_en.tex
+++ b/tasks/implementation/VHDL/MC_CU/templates/task_description/task_description_template_en.tex
@@ -8,9 +8,9 @@
 
 \newlength{\maxheight}
 \setlength{\maxheight}{\heightof{W}}
-\newcommand{\baselinealign}[1]{%
+\newcommand{\baselinealign}[1]{ %
 	\centering
-	\raisebox{0pt}[\maxheight][0pt]{#1}%
+	\raisebox{0pt}[\maxheight][0pt]{ #1}%
 }
 
 \newcommand\Tstrut{\rule{0pt}{2.6ex}}       % "top" strut
@@ -96,9 +96,9 @@ Do not change the file ``MC\_CU.vhdl".\\
 
 You will have to implement the following types of instructions:
 
-%%selected_instruction_type_text
+{{selected_instruction_type_text}}
 
-Before the execution of an instruction the instruction has to be fetched and decoded. This takes two clock cycles. During the fetch clock cycle the instruction is read from the current program counter value (PC) and is saved to the instruction register. Also during the fetch clock cycle the PC register is incremented by 4 using the ALU. The next clock cycle is used to decode the instruction in the control unit. %%beq_bne_decode_addition \\
+Before the execution of an instruction the instruction has to be fetched and decoded. This takes two clock cycles. During the fetch clock cycle the instruction is read from the current program counter value (PC) and is saved to the instruction register. Also during the fetch clock cycle the PC register is incremented by 4 using the ALU. The next clock cycle is used to decode the instruction in the control unit. {{beq_bne_decode_addition}} \\
 
 The ``MC\_CU" entity shall control the multicycle processor depicted in Figure~1 to perform the following instructions:
 
@@ -106,20 +106,20 @@ The ``MC\_CU" entity shall control the multicycle processor depicted in Figure~1
 \centering
     \begin{tabular}{|c|c|c|c|c|} \hline \Tstrut
 		instruction & opcode  & funct & type   \\ \hline \Tstrut
-		%%selected_instruction_table_text
+		{{selected_instruction_table_text}}
     \hline
     \end{tabular}
 \end{table}
 
-%%first_instruction_text \\
+{{first_instruction_text}} \\
 
-%%second_instruction_text \\
+{{second_instruction_text}} \\
 
 \begin{table}[h!]
 \centering
     \begin{tabular}{|c|c|} \hline \Tstrut
 		ALUControl & Function   \\ \hline \Tstrut
-		%%ALUControl_table
+		{{ALUControl_table}}
     \hline
     \end{tabular}
     \caption{ALUControls}
@@ -158,7 +158,7 @@ signal. Use Figure~1 to see how the control signals control the data paths.
 Consider which actions each part of the processor in Figure~1 has to take to fulfill the functions of the operations and set the control signals accordingly. This behavior has to be programmed in the attached file ``MC\_CU\_beh.vhdl".\\
 
 
-To turn in your solution write an email to %%SUBMISSIONEMAIL with Subject ``Result Task %%TASKNR" and attach your behavior file ``MC\_CU\_beh.vhdl"
+To turn in your solution write an email to {{SUBMISSIONEMAIL}} with Subject ``Result Task {{TASKNR}}" and attach your behavior file ``MC\_CU\_beh.vhdl"
 
 
 \vspace{0.7cm}

--- a/tasks/implementation/VHDL/MC_CU/templates/testbench_template.vhdl
+++ b/tasks/implementation/VHDL/MC_CU/templates/testbench_template.vhdl
@@ -110,16 +110,16 @@ begin
       wait until rising_edge(CLK); -- wait for first rising edge
 
       -- instruction test 1:
-      %%instruction_test_1
+      {{instruction_test_1}}
 
       -- instruction test 2:
-      %%instruction_test_2
+      {{instruction_test_2}}
 
       -- instruction test 3:
-      %%instruction_test_3
+      {{instruction_test_3}}
 
       -- instruction test 4:
-      %%instruction_test_4
+      {{instruction_test_4}}
 
       report "Success" severity failure;
    end process;

--- a/tasks/implementation/VHDL/MC_CU/tester.sh
+++ b/tasks/implementation/VHDL/MC_CU/tester.sh
@@ -24,13 +24,13 @@ FAILURE=1
 task_path=$(readlink -f $0|xargs dirname)
 
 #path to common scripts
-common_path=$(readlink -f $task_path/../_common)
+common_path=$(readlink -f ${task_path}/../_common)
 
 # include external config
-source $task_path/task.cfg
+source ${task_path}/task.cfg
 
 #include simulator specific common file
-source $common_path/$commonfile
+source ${common_path}/${commonfile}
 
 #----------------- TEST ----------------
 generate_testbench
@@ -41,9 +41,9 @@ taskfiles_analyze
 
 userfiles_analyze
 
-if [ -n "$constraintfile" ]
+if [ -n "${constraintfile}" ]
 then
-	source $task_path/$constraintfile
+	source ${task_path}/${constraintfile}
 fi
 
 elaborate
@@ -51,9 +51,9 @@ elaborate
 simulate
 
 # catch unhandled cases:
-cd $user_task_path
+cd ${user_task_path}
 touch error_msg
 echo "Error: Unhandled tester case for task ${task_name} for user ${user_id}!"
 echo "Something went wrong with task ${task_nr}. This is not your " \
 "fault. We are working on a solution" > error_msg
-exit $TASKERROR
+exit ${TASKERROR}

--- a/tasks/implementation/VHDL/SC_CU/templates/task_description/task_description_template_de.tex
+++ b/tasks/implementation/VHDL/SC_CU/templates/task_description/task_description_template_de.tex
@@ -25,7 +25,7 @@
 \setlength{\parindent}{0em}
 \section*{Single Cycle Control Unit}
 
-Ihre Aufgabe ist es, das Verhalten einer Entity  namens "`SC\_CU"' zu programmieren. Die Entity ist in der angeh\"angten Datei "`ALU.vhdl"' deklariert und hat folgende Eigenschaften:
+Ihre Aufgabe ist es, das Verhalten einer Entity  namens "`SC\_CU"' zu programmieren. Die Entity ist in der angeh\"angten Datei "`SC\_CU.vhdl"' deklariert und hat folgende Eigenschaften:
 \begin{itemize}
 \item Eingang:  Opcode vom Typ std\_logic\_vector mit einer L\"ange von 6
 \item Eingang:  Funct vom Typ std\_logic\_vector mit einer L\"ange von 6
@@ -97,7 +97,7 @@ Die Entity soll den Single Cycle Prozessor, welcher in Abbildung~1 dargestellt i
     \end{tabular}
 \end{table}
 
-{{SELECTED_INSTRUCTIONS_TEXT}}
+{{SELECTED_INSTRUCTIONS_TEXT}} \\
 
 \begin{table}[h!]
 \centering
@@ -114,32 +114,31 @@ Die Entity soll den Single Cycle Prozessor, welcher in Abbildung~1 dargestellt i
 Um ein besseres Verst\"andnis f\"ur die Steuersignale zu erhalten, sei hier eine Beschreibung aller Signale gegeben. Verwenden Sie Abbildung~1 um zu verstehen, wie die Steuersignale die Datenpfade steuern.
 \begin{itemize}
 
-	\item{RegDst: Bestimmt, ob die Zieladresse des Registers entweder von den Bits 20 -- 16 oder 15 -- 11 der Instruktion definiert wird. In anderen Worten entscheidet dieses Steuersignal, ob das Zielregister durch rt oder rd festgelegt wird.}
+	\item{RegDst: Bestimmt, ob die Position des zu beschreibenden Registers "`Write Register"' entweder von den Bits 20 -- 16 oder 15 -- 11 der Instruktion definiert wird. In anderen Worten entscheidet dieses Steuersignal, ob das zu beschreibende Register durch rt oder rd festgelegt wird.}
 
 	\item{Branch: Hat einen Effekt auf die Quelle f\"ur den n\"achsten Wert des Befehlsz\"ahlers (PC). Wenn die Branch Bedingung erf\"ullt ist, ist der Wert '1'. Ist die aktuelle Instruktion keine Branch Instruktion, so ist der Wert immer '0'.}
-
 
 	\item{Jump: Hat einen Einfluss auf die Quelle f\"ur den n\"achsten Wert des Befehlsz\"ahlers (PC). Ist die aktuelle Instruktion keine Jump Instruktion, so ist der Wert immer '0'.}
 
 	\item{MemRead: Wenn das MemRead Signal auf '1' gesetzt ist, dann gibt der Datenspeicher "`Data memory"' jene Daten aus, welche durch den Adresseingang "`Read address"' bestimmt werden.}
 
-	\item{MemtoReg: Bestimmt, ob die in das Register zu schreibenden Daten "`Write data"' entweder vom Ausgang des Datenspeichers "`Data memory"' oder der ALU kommen.}
+	\item{MemtoReg: Bestimmt, ob die in das Register zu schreibenden Daten "`Write data"' entweder vom Ausgang des Datenspeichers "`Data memory"' oder dem ALU Ausgang "`Result"' kommen.}
 
-	\item{MemWrite: Wenn dieses Signal auf '1' gesetzt ist, dann schreibt der Datenspeicher "`Data memory"' seine Daten ("`Write data"') an die Zieladresse "`Write address"'.}
+	\item{MemWrite: Wenn dieses Signal auf '1' gesetzt ist, dann schreibt der Datenspeicher "`Data memory"' seine Eingangsdaten ("`Write data"') an die Zieladresse "`Write address"'.}
 
 	\item{ALUControl: W\"ahlt jene ALU Operation aus, welche die ALU auf ihre zwei Eingangswerte anwendet. Die Steuersignale f\"ur die verf\"ugbaren Operationen sind in Tabelle~1 gelistet.}
 
 	\item{ALUSrc: Bestimmt, ob die ALU einen Wert entweder von dem Ausgang "`Read data 2"' des Registers oder von dem vorzeichenerweiterten Wert IMM der Instruktion erh\"alt.}
 
-	\item{RegWrite: Wenn das RegWrite Signal auf '1' gesetzt ist, dann schreibt das Register die Daten "`Write data"' in das Register "`Write register"'.\\}
+	\item{RegWrite: Wenn das RegWrite Signal auf '1' gesetzt ist, dann schreibt das Register die Eigangsdaten "`Write data"' in das durch "`Write register"' adressierte Register.\\}
 
 \end{itemize}
 
-\"Uberlegen Sie sich, welche Aktion jeder Teil des Prozessors f\"ur die Funktion der jeweiligen Instruktionen erf\"ullen muss und setzen Sie die Steuersignale entsprechend. Programmieren Sie dieses Verhalten in der angeh\"angten Datei "`ALU\_beh.vhdl"'.\\
+\"Uberlegen Sie sich, welche Aktion jeder Teil des Prozessors f\"ur die Funktion der jeweiligen Instruktionen erf\"ullen muss und setzen Sie die Steuersignale entsprechend. Programmieren Sie dieses Verhalten in der angeh\"angten Datei "`SC\_CU\_beh.vhdl"'.\\
 
-Um Ihre L\"osung abzugeben, senden Sie ein E-Mail mit dem Betreff "`Result Task {{ TASKNR }}"' und Ihrer Datei "`truth\_table\_beh.vhdl"'  an {{ SUBMISSIONEMAIL }}.
+Um Ihre L\"osung abzugeben, senden Sie ein E-Mail mit dem Betreff "`Result Task {{ TASKNR }}"' und Ihrer Datei "``SC\_CU\_beh.vhdl"'  an {{ SUBMISSIONEMAIL }}.
 
-\vspace{0.7cm}
+\vspace{0.5cm}
 
 Viel Erfolg und m\"oge die Macht mit Ihnen sein.
 

--- a/tasks/implementation/VHDL/fsm/templates/task_description/task_description_template_de.tex
+++ b/tasks/implementation/VHDL/fsm/templates/task_description/task_description_template_de.tex
@@ -56,7 +56,7 @@ Ver\"andern Sie die Datei "`fsm.vhdl"' nicht!
 
 Die Entity "`fsm"' soll das Verhalten einer deterministischen Finite State Machine wiedergeben und dabei folgende Eigenschaften erf\"ullen:
 \begin{itemize}
-\item Ein Verhalten entsprechend dem Zustands\"ubergangsdiagramm in Abbildung \ref{state_image}. Der Eingang, welcher an den n\"achsten Zustand weitergegeben wird, und der Ausgang im n\"achsten Zustand sind an den Kanten angegeben.
+\item Ein Verhalten entsprechend dem Zustands\"ubergangsdiagramm in Abbildung \ref{state_image}. Der Eingang, welcher zu dem n\"achsten Zustand führt, und der Ausgang im n\"achsten Zustand sind an den Kanten angegeben.
 \item \"Ubertragungen mit steigender Flanke des Taktsignals (Port CLK; dies ist ein rechteckiges Taktsignal)
 \item  Synchrones Design: Alle neuen Ausg\"ange (Port STATE und Port OUTPUT) m\"ussen mit der steigenden Taktflanke gesetzt werden.
 \item Der aktuelle Zustand muss am Ausgangsport STATE ausgegeben werden.

--- a/tasks/implementation/VHDL/timingDemo/generator.sh
+++ b/tasks/implementation/VHDL/timingDemo/generator.sh
@@ -13,102 +13,103 @@
 ##########################
 ####### PARAMETERS #######
 ##########################
-# $1 ... UserId
-# $2 ... TaskNr
-# $3 ... Submission Email
-# $4 ... Mode
-# $5 ... Semester DB
+user_id=$1
+task_nr=$2
+submission_email=$3
+mode=$4
+semester_db=$5
+language=$6
 
 ##########################
 ########## PATHS #########
 ##########################
 # src path of autosub system
-autosubPath=$(pwd)
+autosub_path=$(pwd)
 # root path of the task itself
-taskPath=$(readlink -f $0|xargs dirname)
+task_path=$(readlink -f $0|xargs dirname)
 # path for all the files that describe the created path
-descPath="$autosubPath/users/$1/Task$2/desc"
+desc_path="${autosub_path}/users/${user_id}/Task${task_nr}/desc"
 
 ##########################
 ##### PATH CREATIONS #####
 ##########################
-if [ ! -d "$taskPath/tmp" ]
+if [ ! -d "${task_path}/tmp" ]
 then
-   mkdir $taskPath/tmp
+   mkdir ${task_path}/tmp
 fi
 
-if [ ! -d "$descPath" ]
+if [ ! -d "${desc_path}" ]
 then
-   mkdir $descPath
+   mkdir ${desc_path}
 fi
 
 ##########################
 ####### GENERATE #########
 ##########################
-cd $taskPath
+cd ${task_path}
 
-task_parameters=$(python3 scripts/generateTask.py "$1" "$2" "$3")
+task_parameters=$(python3 scripts/generateTask.py "${user_id}" "${task_nr}" "${submission_email}" "${language}")
 
 #generate the description pdf and move it to user's description folder
-cd $taskPath/tmp
+cd ${task_path}/tmp
 
-latex --halt-on-error desc_$1_Task$2.tex >/dev/null 2>/dev/null
+latex --halt-on-error desc_${user_id}_Task${task_nr}.tex >/dev/null 2>/dev/null
 RET=$?
 zero=0
 if [ "$RET" -ne "$zero" ];
 then
-    echo "ERROR with pdf generation for Task$2 !!! Are all needed LaTeX packages installed??">&2
+    echo "ERROR with pdf generation for Task${task_nr} !!! Are all needed LaTeX packages installed??">&2
 fi
 
-dvips desc_$1_Task$2.dvi >/dev/null 2>/dev/null
-ps2pdf desc_$1_Task$2.ps >/dev/null 2>/dev/null
+dvips desc_${user_id}_Task${task_nr}.dvi >/dev/null 2>/dev/null
+ps2pdf desc_${user_id}_Task${task_nr}.ps >/dev/null 2>/dev/null
 
-rm desc_$1_Task$2.dvi
-rm desc_$1_Task$2.aux
-rm desc_$1_Task$2.ps
-rm desc_$1_Task$2.log
-rm desc_$1_Task$2.tex
-mv $taskPath/tmp/desc_$1_Task$2.pdf $descPath
+rm desc_${user_id}_Task${task_nr}.dvi
+rm desc_${user_id}_Task${task_nr}.aux
+rm desc_${user_id}_Task${task_nr}.ps
+rm desc_${user_id}_Task${task_nr}.log
+rm desc_${user_id}_Task${task_nr}.tex
+mv ${task_path}/tmp/desc_${user_id}_Task${task_nr}.pdf ${desc_path}
 
 #copy static files to user's description folder
-cp $taskPath/static/timingDemo.vhdl $descPath
-cp $taskPath/static/timingDemo_beh.vhdl $descPath
-cp $taskPath/static/timingDemo_example.vhdl $descPath
+cp ${task_path}/static/timingDemo.vhdl ${desc_path}
+cp ${task_path}/static/timingDemo_beh.vhdl ${desc_path}
+cp ${task_path}/static/timingDemo_example.vhdl ${desc_path}
 
 
 #for exam
-#cp $taskPath/exam/testbench_exam.vhdl $descPath/gates_tb_exam.vhdl
+#cp ${task_path}/exam/testbench_exam.vhdl ${desc_path}/gates_tb_exam.vhdl
 
 
 ############### ONLY FOR TESTING #################
-mv $taskPath/tmp/solution_$1_Task$2.txt $descPath
-mv $taskPath/tmp/result_check_$1_Task$2.txt $descPath
+mv ${task_path}/tmp/solution_${user_id}_Task${task_nr}.txt ${desc_path}
+mv ${task_path}/tmp/result_check_${user_id}_Task${task_nr}.txt ${desc_path}
 ##################################################
 
 ##########################
 ##   EMAIL ATTACHMENTS  ##
 ##########################
 
-taskAttachments=""
-taskAttachmentsBase="$descPath/desc_$1_Task$2.pdf $descPath/timingDemo_example.vhdl $descPath/timingDemo.vhdl $descPath/timingDemo_beh.vhdl"
+task_attachments=""
+task_attachments_base="${desc_path}/desc_${user_id}_Task${task_nr}.pdf ${desc_path}/timingDemo_example.vhdl ${desc_path}/timingDemo.vhdl ${desc_path}/timingDemo_beh.vhdl"
 
-#if [ -n "$4" ];
+#if [ -n "${mode}" ];
 #then
-#    if [ "$4" = "exam" ];
+#    if [ "${mode}" = "exam" ];
 #    then
-#        taskAttachments="$taskAttachmentsBase $descPath/gates_tb_exam.vhdl"
+#        task_attachments="${task_attachments_base} ${desc_path}/gates_tb_exam.vhdl"
 #    fi
 #fi
-if [ -z "$4" ] || [ "$4" = "normal" ]; #default to normal
+if [ -z "${mode}" ] || [ "${mode}" = "normal" ]; #default to normal
 then
-    taskAttachments="$taskAttachmentsBase"
+    task_attachments="${task_attachments_base}"
 fi
 
 ##########################
 ## ADD TASK TO DATABASE ##
 ##########################
 #NOTE: do not attach solution in final version :)
-cd $autosubPath/tools
-python3 add_to_usertasks.py -u $1 -t $2 -p "$task_parameters" -a "$taskAttachments" -d $5
+cd ${autosub_path}/tools
+python3 add_to_usertasks.py -u ${user_id} -t ${task_nr} -p "${task_parameters}" -a "${task_attachments}" -d ${semester_db}
 
-cd $autosubPath
+cd ${autosub_path}

--- a/tasks/implementation/VHDL/timingDemo/scripts/generateTask.py
+++ b/tasks/implementation/VHDL/timingDemo/scripts/generateTask.py
@@ -14,18 +14,13 @@ import string
 import sys
 import fileinput
 
-###########################
-##### TEMPLATE CLASS ######
-###########################
-class MyTemplate(string.Template):
-    delimiter = "%%"
-
+from jinja2 import FileSystemLoader, Environment
 #################################################################
 
 userId=sys.argv[1]
 taskNr=sys.argv[2]
 submissionEmail=sys.argv[3]
-
+language=sys.argv[4]
 paramsDesc={}
 
 ###########################
@@ -221,25 +216,27 @@ with open (filename, "w") as solution:
     solution.write("For TaskParameters: " + str(taskParameters) + "\n")
 
 #task solution
-filename ="templates/solution_template.txt"
-with open (filename, "r") as template_file:
-	data=template_file.read()
+env = Environment()
+env.loader = FileSystemLoader('templates/')
+filename ="solution_template.txt"
+template = env.get_template(filename)
+template = template.render(paramsDesc)
+
 filename ="tmp/solution_{0}_Task{1}.txt".format(userId,taskNr)
 with open (filename, "w") as output_file:
-	s = MyTemplate(data)
-	output_file.write(s.substitute(paramsDesc))
-
+    output_file.write(template)
 #############################
 # FILL DESCRIPTION TEMPLATE #
 #############################
+env = Environment()
+env.loader = FileSystemLoader('templates/')
+filename ="task_description/task_description_template_{0}.tex".format(language)
+template = env.get_template(filename)
+template = template.render(paramsDesc)
 
-filename ="templates/task_description_template.tex"
-with open (filename, "r") as template_file:
-	data=template_file.read()
 filename ="tmp/desc_{0}_Task{1}.tex".format(userId,taskNr)
 with open (filename, "w") as output_file:
-	s = MyTemplate(data)
-	output_file.write(s.substitute(paramsDesc))
+    output_file.write(template)
 
 ###########################
 ### PRINT TASKPARAMETERS ##

--- a/tasks/implementation/VHDL/timingDemo/scripts/generateTestBench.py
+++ b/tasks/implementation/VHDL/timingDemo/scripts/generateTestBench.py
@@ -13,11 +13,7 @@ import string
 import ast
 from random import shuffle
 
-###########################
-##### TEMPLATE CLASS ######
-###########################
-class MyTemplate(string.Template):
-    delimiter = "%%"
+from jinja2 import FileSystemLoader, Environment
 
 #################################################################
 
@@ -25,8 +21,6 @@ params={}
 
 taskParameter=ast.literal_eval(sys.argv[1])
 #x=sys.argv[1]
-
-
 
 
 #########################################
@@ -65,16 +59,12 @@ params.update({"TESTPATTERN":testPattern, "time_o1":(ONS1-1), "time_p1":(PNS1-ON
 ###########################
 # FILL TESTBENCH TEMPLATE #
 ###########################
-filename ="templates/testbench_template.vhdl"
-with open (filename, "r") as template_file:
-    data=template_file.read()
-    s = MyTemplate(data)
-    print(s.substitute(params))
+env = Environment()
+env.loader = FileSystemLoader('templates/')
+filename ="testbench_template.vhdl"
 
-#filename ="tmp/testbench_template1.vhdl"
-#with open (filename, "w") as output_file:
-#	s = MyTemplate(data)
-#	output_file.write(s.substitute(params))
+template = env.get_template(filename)
+template = template.render(params)
 
-#########################################
+print(template)
 

--- a/tasks/implementation/VHDL/timingDemo/templates/solution_template.txt
+++ b/tasks/implementation/VHDL/timingDemo/templates/solution_template.txt
@@ -1,7 +1,7 @@
 p1:
- A := A + %%value_a
- N <= N + %%value_n
- O <= %%c1 * A + %%c2 * N after %%delay_o
- P <= %%c3 * A - %%c4 * N after %%delay_p
+ A := A + {{value_a}}
+ N <= N + {{value_n}}
+ O <= {{c1}} * A + {{c2}} * N after {{delay_o}}
+ P <= {{c3}} * A - {{c4}} * N after {{delay_p}}
 p2:
- E <= %%c5 * O + %%c6 * E after %%delay_e
+ E <= {{c5}} * O + {{c6}} * E after {{delay_e}}

--- a/tasks/implementation/VHDL/timingDemo/templates/task_description/task_description_template_en.tex
+++ b/tasks/implementation/VHDL/timingDemo/templates/task_description/task_description_template_en.tex
@@ -7,7 +7,7 @@
 \usetikzlibrary{calc}
 
 \definecolor{forestgreen}{rgb}{0.1, 0.7, 0.0}
-\newcommand\tab[1][1cm]{\hspace*{#1}}
+\newcommand\tab[1][1cm]{\hspace*{ #1} }
 
 \begin{document}
 \pagestyle{empty}
@@ -104,7 +104,7 @@ The timing behavior has to be programmed in the attached file "timingDemo\_beh.v
 In the file "timingDemo\_beh.vhdl" there are two process, p1 and p2. One should includes the signal corresponded to E only and be triggered by signal O and P. For the other process, it should includes the rest of the signals with signal E as its sesitivity list. Your design should declare 4 signals and 1 variable (called "A" here but can be declared any name). All in all, the signals should be assigned to corresponding outputs, N, O, P, or E since the entity is used in this task. Only the behavior of variable A is given and the properties of all signals are demonstrated below:
 \begin{description}
 \item [The variable A]\textbf{:} \\
-The value of the signal is derived by adding %%value_a to itself without delays, as $A := A + %%value_a $. Do not need to assigned A to output signal.
+The value of the signal is derived by adding {{value_a}} to itself without delays, as $A := A + {{value_a}} $. Do not need to assigned A to output signal.
 
 \item [The signal for N]\textbf{:} \\
 The value of the signal is derived by adding an integer to itself and the signal is assigned to signal N.
@@ -113,7 +113,7 @@ The value of the signal is derived by adding an integer to itself and the signal
 The value of the signal is combined with the value of A and N which have coefficients placed before to multiply, as $c_{1} * A + c_{2} * N\_sig$, when $c_{1}$ and $c_{2}$ are integer.
 
 \item [The signal for P]\textbf{:} \\
-The value of the signal is combined with the value of A and N only which have coefficients placed before to multiply, as $c_{3} * A + c_{4} * N\_sig$, when $c_{3}$ and $c_{4}$ are integer. 
+The value of the signal is combined with the value of A and N only which have coefficients placed before to multiply, as $c_{3} * A + c_{4} * N\_sig$, when $c_{3}$ and $c_{4}$ are integer.
 
 \item [The signal for E]\textbf{:} \\
 The value of the signal is combined with the value of O and P only which have coefficients placed before, as $c_{5} * O\_sig + c_{6} * P\_sig$, when $c_{5}$ and $c_{6}$ are integer.
@@ -144,11 +144,11 @@ The figure below shows the waveform running to about 260 ns though the simulatio
 \psline{-}(1.75,7.25)(16.25,7.25)
 \psline{-}(1.75,6.75)(16.25,6.75)
 \rput(16.5,7){...}
-\rput(4.75,7){%%nv1} %value at 0 ns
-\rput(11.25,7){%%nv2}
+\rput(4.75,7){ {{nv1}} } %value at 0 ns
+\rput(11.25,7){ {{nv2}} }
 \psline{-,linecolor=red}(7.75,6.75)(8.25,7.25) %time at 130ns
 \psline{-,linecolor=red}(7.75,7.25)(8.25,6.75)
-\rput(15.5,7){%%nv3}
+\rput(15.5,7){ {{nv3}} }
 \psline{-,linecolor=red}(14.25,6.75)(14.75,7.25) %time at 260ns
 \psline{-,linecolor=red}(14.25,7.25)(14.75,6.75)
 
@@ -158,15 +158,15 @@ The figure below shows the waveform running to about 260 ns though the simulatio
 \psline{-}(1.75,5.75)(16.25,5.75)
 \psline{-}(1.75,5.25)(16.25,5.25)
 \rput(16.5,5.5){...}
-\rput(%%ox1_center,5.5){%%ov1} %first run after %%ons1 ns
-\psline{-,linecolor=blue}(%%ox11, 5.75)(%%ox12, 5.25)
-\psline{-,linecolor=blue}(%%ox11, 5.25)(%%ox12, 5.75)
-\rput(%%ox2_center,5.5){%%ov2} %second run after %%ons2 ns
-\psline{-,linecolor=blue}(%%ox21, 5.75)(%%ox22, 5.25)
-\psline{-,linecolor=blue}(%%ox21, 5.25)(%%ox22, 5.75)
-\rput(%%ox3_center,5.5){%%ov3} %third run
-\psline{-,linecolor=blue}(%%ox31, 5.75)(%%ox32, 5.25)
-\psline{-,linecolor=blue}(%%ox32, 5.75)(%%ox31, 5.25)
+\rput({{ox1_center}},5.5){ {{ov1}} } %first run after {{ons1}} ns
+\psline{-,linecolor=blue}({{ox11}} , 5.75)({{ox12}}, 5.25)
+\psline{-,linecolor=blue}({{ox11}}, 5.25)({{ox12}}, 5.75)
+\rput({{ox2_center}},5.5){ {{ov2}} } %second run after {{ons2}} ns
+\psline{-,linecolor=blue}({{ox21}}, 5.75)({{ox22}}, 5.25)
+\psline{-,linecolor=blue}({{ox21}}, 5.25)({{ox22}}, 5.75)
+\rput({{ox3_center}},5.5){ {{ov3}} } %third run
+\psline{-,linecolor=blue}({{ox31}}, 5.75)({{ox32}}, 5.25)
+\psline{-,linecolor=blue}({{ox32}}, 5.75)({{ox31}}, 5.25)
 
 
 
@@ -176,15 +176,15 @@ The figure below shows the waveform running to about 260 ns though the simulatio
 \psline{-}(1.75,4.25)(16.25,4.25)
 \psline{-}(1.75,3.75)(16.25,3.75)
 \rput(16.5,4){...}
-\rput(%%px1_center,4){%%pv1} %first run after %%pns1 ns
-\psline{-,linecolor=forestgreen}(%%px11, 3.75)(%%px12, 4.25)
-\psline{-,linecolor=forestgreen}(%%px11, 4.25)(%%px12, 3.75)
-\rput(%%px2_center,4){%%pv2} %second run after %%pns2 ns
-\psline{-,linecolor=forestgreen}(%%px21, 3.75)(%%px22, 4.25)
-\psline{-,linecolor=forestgreen}(%%px21, 4.25)(%%px22, 3.75)
-\rput(%%px3_center,4){%%pv3} %third run
-\psline{-,linecolor=forestgreen}(%%px31, 3.75)(%%px32, 4.25)
-\psline{-,linecolor=forestgreen}(%%px32, 3.75)(%%px31, 4.25)
+\rput({{px1_center}},4){ {{pv1}} } %first run after {{pns1}} ns
+\psline{-,linecolor=forestgreen}({{px11}}, 3.75)({{px12}}, 4.25)
+\psline{-,linecolor=forestgreen}({{px11}}, 4.25)({{px12}}, 3.75)
+\rput({{px2_center}},4){ {{pv2}} } %second run after {{pns2}} ns
+\psline{-,linecolor=forestgreen}({{px21}}, 3.75)({{px22}}, 4.25)
+\psline{-,linecolor=forestgreen}({{px21}}, 4.25)({{px22}}, 3.75)
+\rput({{px3_center}},4){ {{pv3}} } %third run
+\psline{-,linecolor=forestgreen}({{px31}}, 3.75)({{px32}}, 4.25)
+\psline{-,linecolor=forestgreen}({{px32}}, 3.75)({{px31}}, 4.25)
 
 
 \rput(1,2.5){E}
@@ -194,10 +194,10 @@ The figure below shows the waveform running to about 260 ns though the simulatio
 \psline{-}(1.75,2.25)(16.25,2.25)
 \rput(16.5,2.5){...}
 \rput(4.75,2.5){0} %value at 0ns
-\rput(11.25,2.5){%%ev2}
+\rput(11.25,2.5){ {{ev2}} }
 \psline{-,linecolor=red}(7.75,2.75)(8.25,2.25) %time at 130ns
 \psline{-,linecolor=red}(7.75,2.25)(8.25,2.75)
-\rput(15.5,2.5){%%ev3}
+\rput(15.5,2.5){ {{ev3}} }
 \psline{-,linecolor=red}(14.25,2.75)(14.75,2.25) %time at 260ns
 \psline{-,linecolor=red}(14.25,2.25)(14.75,2.75)
 
@@ -207,25 +207,25 @@ The figure below shows the waveform running to about 260 ns though the simulatio
 \psline{-}(1.5,1)(16.75,1)
 \psline{-}(16.75,1)(16.5,1.10)
 \psline{-}(16.75,1)(16.5,0.90)
-\rput(%%ox1,0.6){\textcolor{blue}{%%ons1}} %time at %%ons1 ns
-\psline{-,linecolor=blue}(%%ox1,1)(%%ox1,0.8)
-\rput(%%px1,1.4){\textcolor{forestgreen}{%%pns1}} %time at %%pns1 ns
-\psline{-,linecolor=forestgreen}(%%px1,1.2)(%%px1,1)
+\rput({{ox1}},0.6){\textcolor{blue}{ {{ons1}} }} %time at {{ons1}} ns
+\psline{-,linecolor=blue}({{ox1}},1)({{ox1}},0.8)
+\rput({{px1}},1.4){\textcolor{forestgreen}{ {{pns1}} }} %time at {{pns1}} ns
+\psline{-,linecolor=forestgreen}({{px1}},1.2)({{px1}},1)
 \rput(8,0.6){\textcolor{red}{130}} %time at 130ns
 \psline{-,linecolor=red}(8,1)(8,0.8)
-\rput(%%ox2,1.4){\textcolor{blue}{%%ons2}} %time at %%ons2 ns
-\psline{-,linecolor=blue}(%%ox2,1.2)(%%ox2,1)
-\rput(%%px2,0.6){\textcolor{forestgreen}{%%pns2}} %time at %%pns2 ns
-\psline{-,linecolor=forestgreen}(%%px2,1)(%%px2,0.8)
+\rput({{ox2}},1.4){\textcolor{blue}{ {{ons2}} }} %time at {{ons2}} ns
+\psline{-,linecolor=blue}({{ox2}},1.2)({{ox2}},1)
+\rput({{px2}},0.6){\textcolor{forestgreen}{ {{pns2}} }} %time at {{pns2}} ns
+\psline{-,linecolor=forestgreen}({{px2}},1)({{px2}},0.8)
 \rput(14.5,1.4){\textcolor{red}{260}} %time at 260
 \psline{-,linecolor=red}(14.5,1.2)(14.5,1)
 
 \end{pspicture}
 
-Make sure that you understand everything in timingdemo example before starting to code the task. No need to add entity in "timingDemo\_beh.vhdl" when you submit as the entity will be added automatically by the system when simulation checking. 
+Make sure that you understand everything in timingdemo example before starting to code the task. No need to add entity in "timingDemo\_beh.vhdl" when you submit as the entity will be added automatically by the system when simulation checking.
 \\
 \\
-To turn in your solution write an email to %%SUBMISSIONEMAIL with Subject "Result Task %%TASKNR" and attach your file "timingDemo\_beh.vhdl".
+To turn in your solution write an email to {{SUBMISSIONEMAIL}} with Subject "Result Task {{TASKNR}}" and attach your file "timingDemo\_beh.vhdl".
 \\
 \\
 Good Luck and May the Force be with you.

--- a/tasks/implementation/VHDL/timingDemo/templates/testbench_template.vhdl
+++ b/tasks/implementation/VHDL/timingDemo/templates/testbench_template.vhdl
@@ -8,7 +8,7 @@ BEGIN
    	process
 		type result_array is array (natural range <>) of integer;
         	constant expected_result : result_array:=( --w;x;y;z
-			%%TESTPATTERN
+			{{TESTPATTERN}}
 			);
 
 
@@ -25,7 +25,7 @@ BEGIN
 	   wait for 1 ns;
 	   for i in 0 to 2 loop
 
-	   wait for %%time_o1 ns;
+	   wait for {{time_o1}} ns;
 		if N /= expected_result(12*i+0) OR O /= expected_result(12*i+1) OR P /= expected_result(12*i+2) OR  E /= expected_result(12*i+3) then
 		report "§{Error for current time = " & time'image(now) & " (N, O, P, E)= (" & integer'image(N) & ", " & integer'image(O) & ", "
 										 & integer'image(P) & ", " & integer'image(E) & ")" &
@@ -43,7 +43,7 @@ BEGIN
 		severity failure;
 		end if;
 
-  	   wait for %%time_p1 ns;
+  	   wait for {{time_p1}} ns;
 		if N /= expected_result(12*i+4) OR O /= expected_result(12*i+5) OR P /= expected_result(12*i+6) OR  E /= expected_result(12*i+7) then
 		report "§{Error for current time = " & time'image(now) & " (N, O, P, E)= (" & integer'image(N) & ", " & integer'image(O) & ", "
 										 & integer'image(P) & ", " & integer'image(E) & ")" &
@@ -60,7 +60,7 @@ BEGIN
 		severity failure;
 		end if;
 
-	   wait for %%time_e1 ns;
+	   wait for {{time_e1}} ns;
 		if N /= expected_result(12*i+8) OR O /= expected_result(12*i+9) OR P /= expected_result(12*i+10) OR  E /= expected_result(12*i+11) then
 		report "§{Error for current time = " & time'image(now) & " (N, O, P, E)= (" & integer'image(N) & ", " & integer'image(O) & ", "
 										 & integer'image(P) & ", " & integer'image(E) & ")" &

--- a/tasks/implementation/VHDL/timingDemo/tester.sh
+++ b/tasks/implementation/VHDL/timingDemo/tester.sh
@@ -24,13 +24,13 @@ FAILURE=1
 task_path=$(readlink -f $0|xargs dirname)
 
 #path to common scripts
-common_path=$(readlink -f $task_path/../_common)
+common_path=$(readlink -f ${task_path}/../_common)
 
 # include external config
-source $task_path/task.cfg
+source ${task_path}/task.cfg
 
 #include simulator specific common file
-source $common_path/$commonfile
+source ${common_path}/${commonfile}
 
 #----------------- TEST ----------------
 generate_testbench
@@ -41,9 +41,9 @@ taskfiles_analyze
 
 userfiles_analyze
 
-if [ -n "$constraintfile" ]
+if [ -n "${constraintfile}" ]
 then
-	source $task_path/$constraintfile
+	source ${task_path}/${constraintfile}
 fi
 
 elaborate
@@ -51,9 +51,9 @@ elaborate
 simulate
 
 # catch unhandled cases:
-cd $user_task_path
+cd ${user_task_path}
 touch error_msg
 echo "Error: Unhandled tester case for task ${task_name} for user ${user_id}!"
 echo "Something went wrong with task ${task_nr}. This is not your " \
 "fault. We are working on a solution" > error_msg
-exit $TASKERROR
+exit ${TASKERROR}


### PR DESCRIPTION
Corrections in task descriptions of SC_CU
- Fixing some suboptimal descriptions
- Fixing wrong bitrange of J-type description
- Fixing wrong delimiters for Jinja2

Corrections in task descriptions of MC_CU
- Fixing some mess-ups with "rt" and "rd"
- Fixing wrong bitrange of J-type description
- Fixing wrong descriptions of bne and beq instruktion
- Adding German version
