### PR TITLE
VELS_WEB: Discover $server_ip robust to output format changes

### DIFF
--- a/VELS_WEB/daemon.sh
+++ b/VELS_WEB/daemon.sh
@@ -7,7 +7,8 @@ port=8000 #default port
 password="notSecure" #default password
 
 VELS_WEB_PATH=$HOME/web2py/applications/VELS_WEB
-server_ip=$(ip addr | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+server_ip=$(ip -json -family inet addr show scope global | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['addr_info'][0]['local'])")
+
 if [ -n $2 ]; #port given
 then
 	port=$2


### PR DESCRIPTION
* The recent fix still is vulnerable to changes in the output format of 'ip
  addr', and it may fail if more than one active IP addresses are present on the
  system

* The proposed fix asks 'ip addr' to output its data in JSON format, only
  considering 'inet' devices which are exposed to the network ('scope global').

      $ ip -json -family inet addr show scope global | python3 -c "import sys, json; print(json.dumps(json.load(sys.stdin), indent=4))"
      [
          {
              "ifindex": 2,
              "ifname": "ens18",
              "flags": [
                  "BROADCAST",
                  "MULTICAST",
                  "UP",
                  "LOWER_UP"
              ],
              "mtu": 1500,
              "qdisc": "fq_codel",
              "operstate": "UP",
              "group": "default",
              "txqlen": 1000,
              "altnames": [
                  "enp0s18"
              ],
              "addr_info": [
                  {
                      "family": "inet",
                      "local": "111.222.33.4",
                      "prefixlen": 23,
                      "broadcast": "111.222.55.6",
                      "scope": "global",
                      "label": "ens18",
                      "valid_life_time": 4294967295,
                      "preferred_life_time": 4294967295
                  }
              ]
          }
      ]

* Then, a short Python command sequence allows us to parse this JSON output to
  explicitly ask for the device's IP address

      $ ip -json -family inet addr show scope global | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['addr_info'][0]['local'])"
      111.222.33.4